### PR TITLE
Add ionic-broadcast-*

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,14 @@ Example : ionic-css-footer:calm for calm theme footer.
 | Confirm $ionicPopup 	     		| ionic-js-popup:confirm    	 	 		|
 | Prompt $ionicPopup 	     		| ionic-js-popup:prompt  	 	 			|
 
+<h2 name="jspopup">Broadcasts</h2>
+Sometimes you need to broadcast some events to Ionic complete some actions, in `ionic-broadcast-*` you can find all the events you need.
+
+| Snippet Code                     |
+|:--------------------------------:|
+| ionic-broadcast-infinite-scroll  |
+| ionic-broadcast-refresh-complete |
+
 
 ## License
 

--- a/js/broadcasts/scroll-infinite-scroll-complete.sublime-snippet
+++ b/js/broadcasts/scroll-infinite-scroll-complete.sublime-snippet
@@ -1,0 +1,9 @@
+<snippet>
+  <content><![CDATA[
+\$scope.\$broadcast('scroll.infiniteScrollComplete');
+]]></content>
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>ionic-broadcast-infinite-scroll</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <scope>source.js</scope>
+</snippet>

--- a/js/broadcasts/scroll-refresh-complete.sublime-snippet
+++ b/js/broadcasts/scroll-refresh-complete.sublime-snippet
@@ -1,0 +1,9 @@
+<snippet>
+  <content><![CDATA[
+\$scope.\$broadcast('scroll.refreshComplete');
+]]></content>
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>ionic-broadcast-refresh-complete</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <scope>source.js</scope>
+</snippet>


### PR DESCRIPTION
I added the broadcasts that we need to do sometimes

I found these broadcasts by searching for 
1. `broadcast site:ionicframework.com/docs -inurl:forum -inurl:showcase -inurl:present`
1. and `"broadcast the" site:ionicframework.com/docs -inurl:forum -inurl:showcase -inurl:present` on Google.

Just two :) This is something I really need while working, I never remember these names and a palleted of available commands would be nice!

1. `$scope.$broadcast('scroll.refreshComplete');`
    http://ionicframework.com/docs/api/directive/ionRefresher/
1. `$scope.$broadcast('scroll.infiniteScrollComplete');`
    http://ionicframework.com/docs/api/directive/ionInfiniteScroll/

This is simething I care about, right now these snippet only remind us about complete snippets, but not piece of code that is needed. I will make another pull request soon adding all Ionic events that is usually use with `$scope.$on('')` this is another thing really useful

I don't know if you will like the way I put it in the README, feel free to edit :)